### PR TITLE
fix: repeated dataset setup duplicated across all coreset tests

### DIFF
--- a/tests/test_coreset.py
+++ b/tests/test_coreset.py
@@ -18,18 +18,21 @@
 import numpy as np
 from src.coreset import CoresetSampler
 
+N_ROWS = 1024
+N_COLS = 2
+N_SAMPLES = N_ROWS // 8
+RNG_SEED = 0
+
+
+def _make_data(rng_seed=RNG_SEED):
+    rng = np.random.default_rng(seed=rng_seed)
+    return rng.standard_normal((N_ROWS, N_COLS)), rng
+
 
 def test_coreset_outliers():
     """Test if coreset always includes diverse points (outliers)"""
-    n_rows = 1024
-    n_cols = 2
-    n_samples = n_rows // 8
-
-    cs = CoresetSampler(n_samples=n_samples, random_seed=0)
-
-    rng = np.random.default_rng(seed=0)
-
-    x = rng.standard_normal((n_rows, n_cols))
+    cs = CoresetSampler(n_samples=N_SAMPLES, random_seed=0)
+    x, _ = _make_data()
     x[14, 0] = -100
     x[77, 1] = 100
 
@@ -41,15 +44,10 @@ def test_coreset_outliers():
 
 def test_coreset_determinism():
     """Test if coreset sampling output is always the same given random seed."""
-    n_rows = 1024
-    n_cols = 2
-    n_samples = n_rows // 8
+    x, _ = _make_data()
 
-    cs1 = CoresetSampler(n_samples=n_samples, random_seed=4)
-    cs2 = CoresetSampler(n_samples=n_samples, random_seed=4)
-
-    rng = np.random.default_rng(seed=0)
-    x = rng.standard_normal((n_rows, n_cols))
+    cs1 = CoresetSampler(n_samples=N_SAMPLES, random_seed=4)
+    cs2 = CoresetSampler(n_samples=N_SAMPLES, random_seed=4)
 
     cs1.initialize(x)
     indices1 = cs1.sample(x)
@@ -62,18 +60,23 @@ def test_coreset_determinism():
 
 def test_coreset_std():
     """Test if coreset sampling is more diverse than random sampling."""
-    n_rows = 1024
-    n_cols = 2
-    n_samples = n_rows // 8
-
-    cs = CoresetSampler(n_samples=n_samples, random_seed=0)
-
-    rng = np.random.default_rng(seed=0)
-    x = rng.standard_normal((n_rows, n_cols))
+    cs = CoresetSampler(n_samples=N_SAMPLES, random_seed=0)
+    x, rng = _make_data()
 
     cs.initialize(x)
     indices = cs.sample(x)
 
-    indices_rnd = rng.choice(n_rows, n_samples)
+    random_indices = rng.choice(N_ROWS, N_SAMPLES)
 
-    assert x[indices].std() > x[indices_rnd].std()
+    assert x[indices].std() > x[random_indices].std()
+
+
+def test_coreset_sample_count():
+    """Test if coreset returns exactly n_samples valid indices."""
+    cs = CoresetSampler(n_samples=N_SAMPLES, random_seed=0)
+    x, _ = _make_data()
+    cs.initialize(x)
+    indices = cs.sample(x)
+    assert len(indices) == N_SAMPLES
+    assert np.all(indices >= 0)
+    assert np.all(indices < N_ROWS)


### PR DESCRIPTION
This PR addresses the following issue in `tests/test_coreset.py`: repeated dataset setup duplicated across all coreset tests.

## Changes
- `tests/test_coreset.py`: repeated dataset setup duplicated across all coreset tests.

## Details
```diff
--- a/tests/test_coreset.py
+++ b/tests/test_coreset.py
@@ -19,6 +19,16 @@
 import numpy as np
 from src.coreset import CoresetSampler
+
+N_ROWS = 1024
+N_COLS = 2
+N_SAMPLES = N_ROWS // 8
+RNG_SEED = 0
+
+
+def _make_data(rng_seed=RNG_SEED):
+    rng = np.random.default_rng(seed=rng_seed)
+    return rng.standard_normal((N_ROWS, N_COLS)), rng
 
 
 def test_coreset_outliers():
@@ -24,18 +34,11 @@
 def test_coreset_outliers():
     """Test if coreset always includes diverse points (outliers)"""
-    n_rows = 1024
-    n_cols = 2
-    n_samples = n_rows // 8
-
-    cs = CoresetSampler(n_samples=n_samples, random_seed=0)
-
-    rng = np.random.default_rng(seed=0)
-
-    x = rng.standard_normal((n_rows, n_cols))
+    cs = CoresetSampler(n_samples=N_SAMPLES, random_seed=0)
+    x, _ = _make_data()
     x[14, 0] = -100
     x[77, 1] = 100
 
     cs.initialize(x)
     indices = cs.sample(x)
@@ -44,19 +47,14 @@
 def test_coreset_determinism():
     """Test if coreset sampling output is always the same given random seed."""
-    n_rows = 1024
-    n_cols = 2
-    n_samples = n_rows // 8
+    x, _ = _make_data()
 
-    cs1 = CoresetSampler(n_samples=n_samples, random_seed=4)
-    cs2 = CoresetSampler(n_samples=n_samples, random_seed=4)
+    cs1 = CoresetSampler(n_samples=N_SAMPLES, random_seed=4)
+    cs2 = CoresetSampler(n_samples=N_SAMPLES, random_seed=4)
 
-    rng = np.random.default_rng(seed=0)
-    x = rng.standard_normal((n_rows, n_cols))
-
     cs1.initialize(x)
     indices1 = cs1.sample(x)
@@ -65,17 +60,11 @@
 def test_coreset_std():
     """Test if coreset sampling is more diverse than random sampling."""
-    n_rows = 1024
-    n_cols = 2
-    n_samples = n_rows // 8
+    cs = CoresetSampler(n_samples=N_SAMPLES, random_seed=0)
+    x, rng = _make_data()
 
-    cs = CoresetSampler(n_samples=n_samples, random_seed=0)
-
-    rng = np.random.default_rng(seed=0)
-    x = rng.standard_normal((n_rows, n_cols))
-
     cs.initialize(x)
     indices = cs.sample(x)
 
-    indices_rnd = rng.choice(n_rows, n_samples)
+    random_indices = rng.choice(N_ROWS, N_SAMPLES)
 
-    assert x[indices].std() > x[indices_rnd].std()
+    assert x[indices].std() > x[random_indices].std()
```

## Tests
- `tests/test_coreset.py`

```diff
--- a/tests/test_coreset.py
+++ b/tests/test_coreset.py
@@ -71,3 +71,11 @@
     random_indices = rng.choice(N_ROWS, N_SAMPLES)
 
     assert x[indices].std() > x[random_indices].std()
+
+
+def test_coreset_sample_count():
+    """Test if coreset returns exactly n_samples indices."""
+    cs = CoresetSampler(n_samples=N_SAMPLES, random_seed=0)
+    x, _ = _make_data()
+    cs.initialize(x)
+    indices = cs.sample(x)
+    assert len(indices) == N_SAMPLES
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).